### PR TITLE
fix(engine.rb): Fix the auto load path definitions

### DIFF
--- a/lib/huginn_record_link_agent/engine.rb
+++ b/lib/huginn_record_link_agent/engine.rb
@@ -1,6 +1,6 @@
 module HuginnRecordLinkAgent
   class Engine < ::Rails::Engine
-    config.autoload_paths += Dir["#{config.root}/app/models/**/"]
-    config.autoload_paths += Dir["#{config.root}/app/utils/**/"]
+    config.autoload_paths += Dir["../../app/models/**/"]
+    config.autoload_paths += Dir["../../app/utils/**/"]
   end
 end


### PR DESCRIPTION
Fix the auto load path definitions  for the agent's model and util classes

https://trello.com/c/7gYgl6Rg/95-as-a-developer-i-should-make-sure-the-record-link-agent-works-in-a-staging-environment